### PR TITLE
suppress error report when user cancels purge on file override tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-dependency-manager",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Control mod dependencies through drag&drop",
   "main": "./out/index.js",
   "repository": "",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1077,6 +1077,13 @@ function once(api: types.IExtensionApi) {
             const endTime = new Date().getTime();
             const elapsedTime = (endTime - startTime) / 1000;
             log('info', 'Updated file overrides in ' + elapsedTime + ' seconds');
+          })
+          .catch(err => {
+            // If the user canceled the update (probably during the purge), we don't want to
+            //  throw this error as it will be reportable. Reporting this error instead of the
+            //  error that led to the user canceling the update obfuscates the actual issue.
+            log('warn', 'Failed to update file overrides', err);
+            return (err instanceof util.UserCanceled) ? Promise.resolve() : Promise.reject(err);
           });
       })
       .catch(err => {


### PR DESCRIPTION
Reporting the error as a conflict resolution failure is obfuscating the actual underlining issue

fixes nexus-mods/vortex#15291