### PR TITLE
Fixed rare crash when pre-viewing files in override editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.20] - 2024-11-26
+
+- Fixed attempts to render file override editor entries of mods that are being uninstalled in the background.
+
+## [0.2.19] - 2024-08-20
+
+- Improved rules/override suppression checks
+- fixed inability to assign overrides in the override editor
+
 ## [0.2.18] - 2024-08-20
 
 - Improved mod version coersion functionality to include pre-release information in generated rules.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-dependency-manager",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Control mod dependencies through drag&drop",
   "main": "./out/index.js",
   "repository": "",

--- a/src/views/OverrideEditor.tsx
+++ b/src/views/OverrideEditor.tsx
@@ -391,7 +391,9 @@ class OverrideEditor extends ComponentEx<IProps, IComponentState> {
       const options = node.providers.sort((lhs, rhs) => sortIdx(lhs) - sortIdx(rhs))
         .reduce((accum, modId) => {
           const mod = mods[modId];
-          if (mod === undefined) {
+          if (!mod || mod?.type === undefined) {
+            // Can only happen if the mod gets uninstalled in the background while the override
+            //  editor is in view.
             return accum;
           }
           const relPath = (pathTool.isAbsolute(filePath))


### PR DESCRIPTION
Caused by a race condition - mod gets uninstalled in the background

fixes nexus-mods/vortex#16692