### PR TITLE
fixed overrides not clearing upon removal of winning mod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-dependency-manager",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "Control mod dependencies through drag&drop",
   "main": "./out/index.js",
   "repository": "",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -251,7 +251,13 @@ async function updateOverrides(api: types.IExtensionApi, startTime: number, batc
     const modOverrides = mod.fileOverrides || [];
     const invalidOverrides: string[] = modOverrides.reduce((accum, o) => { 
       const hasConflict = conflicts.some(c => c.files.includes(o));
-      if (!hasConflict) {
+      const canFileDeploy = conflicts
+        .filter(c => c.files.includes(o))
+        .some(c => {
+          const otherMod = enabled.find(m => m.id === c.otherMod.id);
+          return !otherMod?.fileOverrides?.includes(o);
+        });
+      if (!hasConflict || !canFileDeploy) {
         accum.push(o);
       }
       return accum;

--- a/src/util/conflicts.ts
+++ b/src/util/conflicts.ts
@@ -3,7 +3,6 @@ import { ConflictSuggestion, IConflict } from '../types/IConflict';
 import { IModLookupInfo } from '../types/IModLookupInfo';
 import isBlacklisted from './blacklist';
 import * as path from 'path';
-import * as semver from 'semver';
 import turbowalk from 'turbowalk';
 import { log, types, util } from 'vortex-api';
 

--- a/src/views/ConflictEditor.tsx
+++ b/src/views/ConflictEditor.tsx
@@ -282,12 +282,21 @@ class ConflictEditor extends ComponentEx<IProps, IComponentState> {
     this.context.api.showDialog('question', t('Confirm'), {
       text: t('This change will only be applied once you choose to "Save" the change in the main '
         + 'dialogue window. Please be aware that once saved, this action cannot be undone and the '
-        + 'mod rules will have to be set again.'),
+        + 'mod rules and file overrides will have to be set again.'),
     }, [
         { label: 'Cancel', default: true },
         {
           label: 'Clear Rules',
           action: () => {
+            const batchedActions: Redux.Action[] = [];
+            for (const modId of modIds || []) {
+              if (Array.isArray(this.props.mods[modId]?.fileOverrides)) {
+                batchedActions.push(vortexActions.setFileOverride(this.props.gameId, modId, []));
+              }
+            }
+            if (batchedActions.length > 0) {
+              this.props.onBatchDispatch(batchedActions);
+            }
             this.nextState.rules = (modIds || []).reduce(
               (prev: { [modId: string]: { [refId: string]: IRuleSpec } }, modId: string) => {
                 const res: { [modId: string]: IRuleSpec } = {};


### PR DESCRIPTION
file overrides will now clear correctly if they become redundant

- also modified the "Clear Rules" action in the mod level conflict resolution dialog to clear file overrides too.